### PR TITLE
[Feat] 검색어 추천 캐싱기능 구현

### DIFF
--- a/src/components/SearchRecommends/SearchRecommendItem/index.tsx
+++ b/src/components/SearchRecommends/SearchRecommendItem/index.tsx
@@ -16,7 +16,6 @@ function SearchRecommendItem({
     ? [styles.item, styles.selected].join(' ')
     : styles.item;
 
-  console.log(className);
   return (
     <li className={className} id={`recommend_id_${id}`}>
       <SearchIcon className={styles.search_icon} />

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -47,6 +47,12 @@ const useSearch = ({ cacheExpire = 300, cacheLimit = 100 }: UseSearchProps) => {
 
       if (isValidTime(expireTime)) {
         setRecommendList(data);
+
+        cache.set(searchKeyword, {
+          data,
+          expireTime,
+          lastAccessedTime: new Date(),
+        });
         return;
       }
 

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { SearchRecommendType } from '@/types/recommend.type';
+import { search } from '@/services/searchApi';
+import { addSeconds, isValidTime } from '@/utils/tilme';
+
+interface CachedRecommendType {
+  data: SearchRecommendType[];
+  expireTime: Date;
+  lastAccessedTime: Date;
+}
+
+interface UseSearchProps {
+  cacheExpire?: number;
+  cacheLimit?: number;
+}
+
+const cache = new Map<string, CachedRecommendType>();
+
+const useSearch = ({ cacheExpire = 300, cacheLimit = 100 }: UseSearchProps) => {
+  const [recommendList, setRecommendList] = useState<SearchRecommendType[]>([]);
+
+  const checkCacheLimit = () => {
+    return cache.size > cacheLimit;
+  };
+
+  const removeOldestAccessedItem = () => {
+    let oldestKey = '';
+    let oldestAccessedTime = new Date();
+
+    for (const [key, value] of cache.entries()) {
+      if (value.lastAccessedTime < oldestAccessedTime) {
+        oldestKey = key;
+        oldestAccessedTime = value.lastAccessedTime;
+      }
+    }
+
+    if (oldestKey) {
+      cache.delete(oldestKey);
+    }
+  };
+
+  const fetchingSearch = async (searchKeyword: string) => {
+    const cachedData = cache.get(searchKeyword);
+
+    if (cachedData) {
+      const { data, expireTime } = cachedData;
+
+      if (isValidTime(expireTime)) {
+        setRecommendList(data);
+        return;
+      }
+
+      cache.delete(searchKeyword);
+    }
+
+    const data = await search(encodeURI(searchKeyword));
+
+    const expireTime = addSeconds(cacheExpire);
+    const lastAccessedTime = new Date();
+    cache.set(searchKeyword, { data, expireTime, lastAccessedTime });
+
+    if (checkCacheLimit()) {
+      removeOldestAccessedItem();
+    }
+
+    setRecommendList(data);
+  };
+
+  const resetCache = () => {
+    cache.clear();
+  };
+
+  return { recommendList, fetchingSearch, resetCache };
+};
+
+export default useSearch;

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -3,11 +3,13 @@ import styles from '@pages/HomePage/HomePage.module.css';
 import HomeTitle from '@components/HomeTitle';
 import SearchForm from '@/components/SearchForm';
 import SearchRecommends from '@/components/SearchRecommends';
-import { search } from '@/services/searchApi';
-import { SearchRecommendType } from '@/types/recommend.type';
+import useSearch from '@/hooks/useSearch';
 
 function HomePage() {
-  const [recommendList, setRecommendList] = useState<SearchRecommendType[]>([]);
+  const { recommendList, fetchingSearch } = useSearch({
+    cacheExpire: 300,
+    cacheLimit: 100,
+  });
   const [isFocused, setIsFocused] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
 
@@ -25,9 +27,7 @@ function HomePage() {
       return;
     }
 
-    const response = await search(encodeURI(searchKeyword));
-
-    setRecommendList(response);
+    await fetchingSearch(searchKeyword);
   };
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
@@ -52,8 +52,6 @@ function HomePage() {
       return;
     }
   };
-
-  console.log(selectedIndex);
 
   return (
     <section className={styles.home_wrapper}>

--- a/src/utils/tilme/index.ts
+++ b/src/utils/tilme/index.ts
@@ -1,0 +1,10 @@
+export const addSeconds = (seconds: number) => {
+  const currentDate = new Date();
+  const futureDate = new Date(currentDate.getTime() + seconds * 1000);
+  return futureDate;
+};
+
+export const isValidTime = (date: Date) => {
+  const currentDate = new Date();
+  return date.getTime() > currentDate.getTime();
+};


### PR DESCRIPTION
### 개발 내용
- #3 
- 데이터 캐싱 기능 구현
  - 기본 로직
     - cache에 존재하지 않는 경우
       - 검색어 추천 api 요청
       - cache에 data, key(검색키워드), lastAccessedTime 저장
     - cache에 존재하여 접근하는 경우 lastAccessedTime을 현재시간으로 업데이트  
       -  cache의 lastAccessedTime를 현재시간으로 업데이트
  - 캐시 데이터 관리
    - Map 자료 구조로 관리
      - Object는 내부적으로 프로토타입 체인을 유지해야 하는 반면, Map은 그렇지 않아 메모리 측면에서 우수
      - Map은 해시 테이블을 사용하여 데이터의 크기가 커져도 평균 시간 복잡도 O(1)으로 데이터하지만, Object 자료구조가 내부적으로 배열과 유사한 구조 느려짐
  - 최대 캐싱 수를 정하고, 접근한지 오래된 데이터 삭제하는 로직
    - **접근한지 오래된 데이터 삭제(LRU)** vs **요청한지 오래된 데이터 삭제** vs **접근 횟수에 따른 삭제(LFU)**
      - 접근한지 오래된 데이터 삭제하도록 정했는데, 이유는 내가 입력하는 검색어들이 연속적으로 타이핑하니까 최근 사용한 검색어들로 캐싱해야 히트율이 높을 것으로 판단되어어서 접근 기준으로 결정 
      - 검색어 접근 횟수에 따른 캐싱 관리할때 최근 겁색어가 사라질 수 있다는 단점이 존재. 추천 검색어는 오히려 최근께 유용할거라고 생각되어 해당 방식 제외
      
      참고: [캐시(Cache) 알고리즘](https://dhpark1212.tistory.com/entry/%EC%BA%90%EC%8B%9CCache-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98)